### PR TITLE
Update Abstract.php

### DIFF
--- a/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
+++ b/app/code/community/Nexcessnet/Turpentine/Model/Varnish/Configurator/Abstract.php
@@ -173,7 +173,11 @@ abstract class Nexcessnet_Turpentine_Model_Varnish_Configurator_Abstract {
      */
     protected function _getAdminFrontname() {
         if (Mage::getStoreConfig('admin/url/use_custom_path')) {
-            return Mage::getStoreConfig('admin/url/custom_path');
+            if(Mage::getStoreConfig('web/url/use_store')) {
+                return Mage::getModel('core/store')->load(0)->getCode() . "/" . Mage::getStoreConfig('admin/url/custom_path');
+            } else {
+                return Mage::getStoreConfig('admin/url/custom_path');
+            }
         } else {
             return (string) Mage::getConfig()->getNode(
                 'admin/routers/adminhtml/args/frontName' );


### PR DESCRIPTION
If in System > Config > Web > Add Store Code to URLs is enabled and a custom admin path is set, then Turpentine will not bypass actions in Magento backend.

This PR checks, if the option is set to active and extends the answer by adding the code from store id 0, which is the admin backend store view.